### PR TITLE
fix: reduce false positives - markdown blocks, test files, git hashes (#10)

### DIFF
--- a/src/scanner.ts
+++ b/src/scanner.ts
@@ -20,6 +20,43 @@ const DEFAULT_IGNORE = [
   'venv', '.tox', 'target', 'pkg', '.cargo',
 ];
 
+const MARKDOWN_EXTENSIONS = new Set(['.md', '.mdx', '.rst']);
+
+const TEST_PATH_PATTERN = /(?:^|\/)(?:test|spec|__tests__|__mocks__|fixtures)\//i;
+const TEST_FILE_PATTERN = /\.(?:test|spec)\.[jt]sx?$/i;
+
+const GIT_HASH_CONTEXT_RE = /(?:checkout|cherry-pick|revert|commit|merge|sha:|sha1:|sha256:|ref:|refs\/|tree\s|parent\s|object\s)\s*[a-f0-9]{40}\b|\b[a-f0-9]{40}\b\s*(?:#\s*(?:commit|sha|ref))/i;
+
+const SEVERITY_DOWNGRADE: Record<Severity, Severity> = {
+  critical: 'high',
+  high: 'medium',
+  medium: 'low',
+  low: 'info',
+  info: 'info',
+};
+
+function isInsideMarkdownCodeBlock(content: string, offset: number): boolean {
+  const before = content.slice(0, offset);
+  // Check fenced code blocks (``` or ~~~)
+  const fencedOpens = (before.match(/^[ \t]*(?:`{3,}|~{3,})/gm) ?? []).length;
+  if (fencedOpens % 2 === 1) return true; // inside an unclosed fence
+
+  // Check 4-space / tab indented code block: the line containing the match
+  const lastNewline = before.lastIndexOf('\n');
+  const lineStart = lastNewline + 1;
+  const linePrefix = content.slice(lineStart, offset);
+  if (/^(?:    |\t)/.test(content.slice(lineStart))) return true;
+
+  return false;
+}
+
+function isGitCommitHash(match: string, lineContext: string): boolean {
+  // Only applies to 40-char lowercase hex strings
+  const hexMatch = match.match(/\b([a-f0-9]{40})\b/);
+  if (!hexMatch) return false;
+  return GIT_HASH_CONTEXT_RE.test(lineContext);
+}
+
 const BINARY_EXTENSIONS = new Set([
   '.jpg', '.jpeg', '.png', '.gif', '.bmp', '.ico', '.svg',
   '.pdf', '.zip', '.tar', '.gz', '.bz2', '.xz', '.7z', '.rar',
@@ -101,15 +138,25 @@ export async function scanFile(
         // False positive filter
         if (rule.falsePositiveFilter?.(matchStr, lineContext)) continue;
 
+        // Filter: 40-char hex git commit hashes
+        if (isGitCommitHash(matchStr, lineContext)) continue;
+
         const maskedMatch = options.showSecrets ? matchStr : maskSecret(matchStr);
         const context = getContextLines(lines, lineIndex);
+
+        // Severity downgrade for markdown code blocks
+        const ext = path.extname(filePath).toLowerCase();
+        let effectiveSeverity = rule.severity;
+        if (MARKDOWN_EXTENSIONS.has(ext) && isInsideMarkdownCodeBlock(content, offset)) {
+          effectiveSeverity = 'info';
+        }
 
         const finding: SecretFinding = {
           id: `${rule.id}-${filePath}-${lineIndex}-${col}`,
           ruleId: rule.id,
           ruleName: rule.name,
           description: rule.description,
-          severity: rule.severity,
+          severity: effectiveSeverity,
           category: rule.category,
           file: filePath,
           line: lineIndex + 1,
@@ -200,11 +247,12 @@ export async function scan(targetPath: string, options: ScanOptions = {}): Promi
   let filesScanned = 0;
   let filesSkipped = 0;
 
-  const TEST_PATH_RE = /(?:^|\/)(?:test|spec|__tests__|__mocks__|fixtures)\//i;
-
   for (const file of files) {
+    const relFile = (stat.isDirectory() ? path.relative(targetPath, file) : path.basename(file)).replace(/\\/g, '/');
+    const isTestFile = TEST_PATH_PATTERN.test(relFile) || TEST_FILE_PATTERN.test(relFile);
+
     // Skip test files if configured
-    if (skipTests && TEST_PATH_RE.test(file.replace(/\\/g, '/'))) {
+    if (skipTests && isTestFile) {
       filesSkipped++;
       continue;
     }
@@ -224,6 +272,14 @@ export async function scan(targetPath: string, options: ScanOptions = {}): Promi
       const filtered = allowlistMatcher
         ? result.findings.filter(f => !allowlistMatcher.isMatchAllowed(f.match))
         : result.findings;
+
+      // Downgrade severity for test files
+      if (isTestFile) {
+        for (const finding of filtered) {
+          finding.severity = SEVERITY_DOWNGRADE[finding.severity];
+        }
+      }
+
       allFindings.push(...filtered);
       filesScanned++;
     }

--- a/test/fixtures/false-positives/docs-example.md
+++ b/test/fixtures/false-positives/docs-example.md
@@ -1,0 +1,14 @@
+# Setup Guide
+
+Install and configure:
+
+```bash
+export OPENAI_API_KEY=sk-proj-aBcDeFgHiJkLmNoPqRsTuVwXyZ01234567890abcdefghijklmno
+export AWS_ACCESS_KEY_ID=AKIAIOSFODNN7EXAMPLE
+```
+
+Also works with indented blocks:
+
+    api_key = "ghp_ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefgh"
+
+This is not in a code block so would still be detected normally.

--- a/test/fixtures/false-positives/git-hashes.sh
+++ b/test/fixtures/false-positives/git-hashes.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+# This file contains git commit hashes that should NOT be flagged as secrets
+git checkout abcdef1234567890abcdef1234567890abcdef12
+git cherry-pick abcdef1234567890abcdef1234567890abcdef12
+git revert abcdef1234567890abcdef1234567890abcdef12
+commit abcdef1234567890abcdef1234567890abcdef12
+sha: abcdef1234567890abcdef1234567890abcdef12

--- a/test/fixtures/false-positives/test/mock-keys.ts
+++ b/test/fixtures/false-positives/test/mock-keys.ts
@@ -1,0 +1,3 @@
+// Test file with mock keys - severity should be downgraded
+const MOCK_AWS_KEY = 'AKIAIOSFODNN7EXAMPLE';
+const MOCK_GITHUB_TOKEN = 'ghp_ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefgh';

--- a/test/scanner.test.ts
+++ b/test/scanner.test.ts
@@ -123,3 +123,52 @@ describe('Scanner - Options', () => {
     assert.ok(result.version, 'Should have version');
   });
 });
+
+describe('Scanner - False Positive Reduction (Issue #10)', () => {
+  test('should downgrade severity for markdown code block findings to info', async () => {
+    const mdFile = path.join(FALSE_POS_DIR, 'docs-example.md');
+    const { findings } = await scanFile(mdFile, ALL_RULES, { showSecrets: true });
+    // Findings inside fenced code blocks should be severity=info
+    const fencedFindings = findings.filter(f => f.line >= 5 && f.line <= 7);
+    for (const f of fencedFindings) {
+      assert.strictEqual(f.severity, 'info', `Finding in markdown code block should be info, got ${f.severity} for ${f.ruleId} at line ${f.line}`);
+    }
+  });
+
+  test('should downgrade severity for indented code block in markdown', async () => {
+    const mdFile = path.join(FALSE_POS_DIR, 'docs-example.md');
+    const { findings } = await scanFile(mdFile, ALL_RULES, { showSecrets: true });
+    // The 4-space indented line is line 11
+    const indentedFindings = findings.filter(f => f.line === 11);
+    for (const f of indentedFindings) {
+      assert.strictEqual(f.severity, 'info', `Finding in indented code block should be info, got ${f.severity} for ${f.ruleId}`);
+    }
+  });
+
+  test('should downgrade severity for test directory files', async () => {
+    const testDir = path.join(FALSE_POS_DIR);
+    const result = await scan(testDir, { showSecrets: true });
+    // Findings from test/ subdirectory should have downgraded severity
+    const testFindings = result.findings.filter(f => f.file.includes('/test/'));
+    for (const f of testFindings) {
+      assert.ok(
+        f.severity !== 'critical',
+        `Test file finding should not be critical, got ${f.severity} for ${f.ruleId} in ${f.file}`
+      );
+    }
+  });
+
+  test('should skip git commit hashes with git context keywords', async () => {
+    const gitFile = path.join(FALSE_POS_DIR, 'git-hashes.sh');
+    const { findings } = await scanFile(gitFile, ALL_RULES, { showSecrets: true });
+    // Should not have findings matching the 40-char hex hashes
+    const hashFindings = findings.filter(f =>
+      f.match.includes('abcdef1234567890abcdef1234567890abcdef12')
+    );
+    assert.strictEqual(
+      hashFindings.length,
+      0,
+      `Should not flag git commit hashes, got ${hashFindings.length} findings: ${hashFindings.map(f => f.ruleId).join(', ')}`
+    );
+  });
+});


### PR DESCRIPTION
Fixes #10

## Changes

### 1. Markdown code block severity downgrade
- `.md`, `.mdx`, `.rst` ファイル内のfenced code block（```〜```）または4スペースインデントブロック内の検出を severity `info` に降格
- `isInsideMarkdownCodeBlock()` でfence開閉カウントとインデント検出を実装

### 2. Test file severity downgrade
- `test/`, `spec/`, `__tests__/`, `__mocks__/`, `fixtures/` ディレクトリ内、または `*.test.ts`, `*.spec.ts` 等のファイルは severity を一段階降格（critical→high, high→medium, etc.）
- 既存の `--skip-tests` オプションとの共存: skip-tests=true なら完全スキップ、false ならダウングレード

### 3. Git commit hash filtering
- 40文字hex文字列で、前後に `checkout`, `commit`, `cherry-pick`, `revert`, `sha:`, `refs/` 等のGitキーワードがある場合は検出をスキップ

### Tests
- 4つの新しいテストケースを追加（全40テスト pass）
- テストフィクスチャ追加: `docs-example.md`, `git-hashes.sh`, `test/mock-keys.ts`